### PR TITLE
Fix too many argments warning

### DIFF
--- a/mpAlign.c
+++ b/mpAlign.c
@@ -2531,7 +2531,7 @@ static void initialization(TOTAL_INFO *info, double **alpha, double **beta) {
   }
 
   if (previous_knowledge_file != NULL) {
-    readPreviousKnowledge(info);
+    readPreviousKnowledge();
   }
 
   for (i = 0; i < sqrt_hash_size; i++) {


### PR DESCRIPTION
clang found the possible bug durning compilation. Fixed.

```
/usr/local/bin/clang -O2   -c -o mpaligner.o mpaligner.c
/usr/local/bin/clang -O2   -c -o HASH_func.o HASH_func.c
/usr/local/bin/clang -O2   -c -o mpAlign.o mpAlign.c
mpAlign.c:2534:31: warning: too many arguments in call to
'readPreviousKnowledge'
    readPreviousKnowledge(info);
    ~~~~~~~~~~~~~~~~~~~~~     ^
1 warning generated.
```